### PR TITLE
Add htmlmin flag removeOptionalTags

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,10 @@ const html = () =>
   gulp
     .src("src/*.html")
     .pipe(inlinesource({ rootpath: path.resolve("dist") }))
-    .pipe(htmlmin({ collapseWhitespace: true }))
+    .pipe(htmlmin({
+      collapseWhitespace: true,
+      removeOptionalTags: true
+    }))
     .pipe(gulp.dest("dist"));
 
 const css = () =>


### PR DESCRIPTION
Adding the removeOptionalTags flag to htmlmin strips out optional tags (in this case head, body), as well as optional closing tags (html). This brings the generated index.html file down from 3,515 bytes to 3,447 bytes before gzip.