### PR TITLE
Add htmlmin collapseBooleanAttributes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,8 @@ const html = () =>
     .pipe(inlinesource({ rootpath: path.resolve("dist") }))
     .pipe(htmlmin({
       collapseWhitespace: true,
-      removeOptionalTags: true
+      removeOptionalTags: true,
+      collapseBooleanAttributes: true
     }))
     .pipe(gulp.dest("dist"));
 


### PR DESCRIPTION
Add htmlmin collapseBooleanAttributes tag, reducing index.html from 3,447 bytes to 3,437 bytes. This will automatically collapse all attributes whose meanings are self evident by their presence (disabled, checked).