### PR TITLE
Add cleanCSS level 2 optimizations flag

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const css = () =>
   gulp
     .src("src/styles/*.css")
     .pipe(
-      cleanCSS({ debug: true }, (details) => {
+      cleanCSS({ debug: true, level: 2 }, (details) => {
         console.log(`${details.name}: ${details.stats.originalSize}`);
         console.log(`${details.name}: ${details.stats.minifiedSize}`);
       })


### PR DESCRIPTION
Add cleanCSS level 2 optimizations flag. This applies more [aggressive css reshaping](https://www.npmjs.com/package/clean-css#level-2-optimizations) such as combining rules and cuts the index.html size from 3,447 bytes to 3,435 bytes.